### PR TITLE
Refine day1 setup copy and retitle/expand day5 intro

### DIFF
--- a/1.1-llm-internals/README.md
+++ b/1.1-llm-internals/README.md
@@ -23,7 +23,8 @@ security boundary between instructions and data.
 
 ### Current-state TODOs
 
-- [ ] Fix setup wording and make credential failures easy to diagnose.
+- [x] Clarify the credential and answer-file setup steps.
+- [ ] Make invalid or missing credential failures easy to diagnose.
 - [ ] Briefly identify [Anthropic content blocks](https://docs.anthropic.com/en/api/messages) and [OpenAI Responses](https://developers.openai.com/api/reference/resources/responses) as formats
       participants will encounter, while keeping one API for the exercise.
 - [ ] Qualify claims about production providers' handling of injected control tokens.

--- a/1.1-llm-internals/section1_instructions.md
+++ b/1.1-llm-internals/section1_instructions.md
@@ -26,12 +26,15 @@ Understand exactly what the model sees and produces — the substrate everything
 
 
 ## Setup
-First, we'll need credentials for OpenRouter API to make LLM calls.
 
-1. **Copy `.env.example` in the root of the project to `.env` and updated it with an OpenRouter API key you should get from the teaching assistants.** This will allow you to run the exercises in this module and future ones that require API access.
+First, set up credentials for the [OpenRouter API](https://openrouter.ai/docs/quickstart)
+and create the file where you will complete the exercises:
 
-
-Next **create a file named `day1_answers.py` in the `1.1-llm-internals` directory. This will be your answer file for today.**
+1. Copy `.env.example` in the project root to `.env`, then add the OpenRouter
+   API key provided by a teaching assistant. The same key is used in later
+   API-based sections.
+2. Create `day1_answers.py` in the `1.1-llm-internals` directory. This will be
+   your answer file for today.
 
 If you see a code snippet here in the instruction file, copy-paste it into your answer file.
 Keep the `# %%` line to make it a Python code cell.

--- a/1.1-llm-internals/section1_solution.py
+++ b/1.1-llm-internals/section1_solution.py
@@ -22,12 +22,15 @@ Understand exactly what the model sees and produces — the substrate everything
 # %%
 """
 ## Setup
-First, we'll need credentials for OpenRouter API to make LLM calls.
 
-1. **Copy `.env.example` in the root of the project to `.env` and updated it with an OpenRouter API key you should get from the teaching assistants.** This will allow you to run the exercises in this module and future ones that require API access.
+First, set up credentials for the [OpenRouter API](https://openrouter.ai/docs/quickstart)
+and create the file where you will complete the exercises:
 
-
-Next **create a file named `day1_answers.py` in the `1.1-llm-internals` directory. This will be your answer file for today.**
+1. Copy `.env.example` in the project root to `.env`, then add the OpenRouter
+   API key provided by a teaching assistant. The same key is used in later
+   API-based sections.
+2. Create `day1_answers.py` in the `1.1-llm-internals` directory. This will be
+   your answer file for today.
 
 If you see a code snippet here in the instruction file, copy-paste it into your answer file.
 Keep the `# %%` line to make it a Python code cell.


### PR DESCRIPTION
## Summary
Copy/structure edits to the day1 and day5 intro sections, made in the `*_solution.py` source of truth with matching changes propagated to the generated `*_instructions.md`.

- **day1**: tighten the Setup wording, fix a grammar slip (`updated` → `update`), and merge the env-key and answer-file steps into a single numbered list.
- **day5**: retitle from "Image Models?" to **"Adversarial Examples in Vision & Language Models"**, and expand the topic list + learning objectives to cover GCG adversarial suffixes and embedding-space prefix tuning (previously only vision attacks and watermarking were listed).

## Notes
- Docs-only; no code/behavior changes.
- Solution files remain the single source of truth; instruction files were regenerated to match.