### PR TITLE
Improvements to AI Control exercises

### DIFF
--- a/2.3-monitoring/day2_utils/generate_trajectories.py
+++ b/2.3-monitoring/day2_utils/generate_trajectories.py
@@ -52,6 +52,7 @@ def generate_trajectories(
     untrusted_model: str = DEFAULT_UNTRUSTED_MODEL,
     max_sandboxes: int = 8,
     max_tasks: int = 2,
+    time_limit: int | None = 120,
 ) -> list[EvalLog]:
     """Run an APPS control evaluation and return the resulting eval logs.
 
@@ -77,6 +78,9 @@ def generate_trajectories(
         max_sandboxes: Max parallel Docker sandboxes per provider. Keep low to
             avoid exhausting Docker's network address pools (~31 networks).
         max_tasks: Max parallel eval tasks (e.g. honest + attack modes).
+        time_limit: Per-sample wall-clock timeout in seconds. Samples that exceed
+            this (e.g. due to a hung LLM call) are killed and counted as errors
+            rather than blocking the entire evaluation. Defaults to 120 s.
 
     Returns:
         List of ``EvalLog`` objects, one per (setting, protocol, mode)
@@ -101,6 +105,7 @@ def generate_trajectories(
         untrusted_model=untrusted_model,
         max_sandboxes=max_sandboxes,
         max_tasks=max_tasks,
+        time_limit=time_limit,
     )
 
     # Create one eval task per (setting, protocol, mode) combination.

--- a/2.3-monitoring/day2_utils/generate_trajectories.py
+++ b/2.3-monitoring/day2_utils/generate_trajectories.py
@@ -55,7 +55,7 @@ def generate_trajectories(
 ) -> list[EvalLog]:
     """Run an APPS control evaluation and return the resulting eval logs.
 
-    By default uses ``apps_solution_policy()`` — a fast dataset replay that
+    You can pass ``apps_solution_policy()`` — a fast dataset replay that
     submits verified solutions and backdoors without any LLM calls. Pass a
     custom ``micro_protocol`` (e.g. ``trusted_monitoring_builder(...)``) for
     LLM-driven attack generation with live monitoring.
@@ -66,7 +66,7 @@ def generate_trajectories(
 
     Args:
         micro_protocol: A ControlArena micro-protocol (policy + optional monitor).
-            Defaults to ``apps_solution_policy()`` — replays dataset solutions,
+            pass ``apps_solution_policy()`` to replay dataset solutions,
             no LLM calls needed.
         limit: Number of samples per eval mode (honest + attack).
         log_dir: Directory to write Inspect eval log files. Created if absent.

--- a/2.3-monitoring/day2_utils/generate_trajectories.py
+++ b/2.3-monitoring/day2_utils/generate_trajectories.py
@@ -50,6 +50,8 @@ def generate_trajectories(
     limit: int = 50,
     trusted_model: str = DEFAULT_TRUSTED_MODEL,
     untrusted_model: str = DEFAULT_UNTRUSTED_MODEL,
+    max_sandboxes: int = 8,
+    max_tasks: int = 2,
 ) -> list[EvalLog]:
     """Run an APPS control evaluation and return the resulting eval logs.
 
@@ -72,6 +74,9 @@ def generate_trajectories(
             and as a fallback in defer-to-trusted protocols.
         untrusted_model: The untrusted (stronger, potentially adversarial) model
             — generates code submissions in LLM-driven protocols.
+        max_sandboxes: Max parallel Docker sandboxes per provider. Keep low to
+            avoid exhausting Docker's network address pools (~31 networks).
+        max_tasks: Max parallel eval tasks (e.g. honest + attack modes).
 
     Returns:
         List of ``EvalLog`` objects, one per (setting, protocol, mode)
@@ -94,6 +99,8 @@ def generate_trajectories(
         log_dir=str(log_dir_path),
         trusted_model=trusted_model,
         untrusted_model=untrusted_model,
+        max_sandboxes=max_sandboxes,
+        max_tasks=max_tasks,
     )
 
     # Create one eval task per (setting, protocol, mode) combination.

--- a/2.3-monitoring/day2_utils/plotting.py
+++ b/2.3-monitoring/day2_utils/plotting.py
@@ -17,37 +17,49 @@ def plot_score_histograms(
     title: str = "Suspicion Score Distribution",
     save_path: Path | None = None,
 ) -> plt.Figure:
-    """Plot overlapping histograms of suspicion scores for honest vs attack runs.
+    """Plot violin distributions of suspicion scores for honest vs attack runs.
 
     If the distributions overlap a lot, the monitor struggles to tell them apart.
     Good monitors produce well-separated distributions.
     """
     fig, ax = plt.subplots(figsize=(8, 5))
 
-    bins = np.linspace(0, 1, 21)  # 20 bins from 0 to 1
-    ax.hist(
-        honest_scores,
-        bins=bins,
-        alpha=0.6,
-        label="Honest",
-        color="green",
-        edgecolor="black",
-        linewidth=0.5,
+    honest_color = "#1db954"
+    attack_color = "#e63946"
+
+    parts = ax.violinplot(
+        [honest_scores, attack_scores],
+        positions=[1, 2],
+        showmedians=True,
     )
-    ax.hist(
+    parts["bodies"][0].set_facecolor(honest_color)
+    parts["bodies"][0].set_alpha(0.75)
+    parts["bodies"][1].set_facecolor(attack_color)
+    parts["bodies"][1].set_alpha(0.75)
+
+    rng = np.random.default_rng(0)
+    jitter = 0.06
+    ax.scatter(
+        1 + rng.uniform(-jitter, jitter, size=len(honest_scores)),
+        honest_scores,
+        color=honest_color,
+        alpha=0.4,
+        s=12,
+        zorder=3,
+    )
+    ax.scatter(
+        2 + rng.uniform(-jitter, jitter, size=len(attack_scores)),
         attack_scores,
-        bins=bins,
-        alpha=0.6,
-        label="Attack",
-        color="red",
-        edgecolor="black",
-        linewidth=0.5,
+        color=attack_color,
+        alpha=0.4,
+        s=12,
+        zorder=3,
     )
 
-    ax.set_xlabel("Suspicion Score (normalized 0-1)")
-    ax.set_ylabel("Count")
+    ax.set_xticks([1, 2])
+    ax.set_xticklabels(["Honest", "Attack"])
+    ax.set_ylabel("Suspicion Score (normalized 0-1)")
     ax.set_title(title)
-    ax.legend()
     ax.grid(True, alpha=0.3)
 
     plt.tight_layout()

--- a/2.3-monitoring/section3_instructions.md
+++ b/2.3-monitoring/section3_instructions.md
@@ -93,13 +93,13 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 
 We now shift from "securing against external attacks on AI systems" to a fundamentally different problem: **securing against the AI system itself**.
 
-Risks from AI agents can be broadly mitigated in two ways: (i) by designing AI agents to be **more trustworthy** (alignment), or (ii) by designing safety measures that **mitigate harms even if AI agents are untrustworthy**. The latter approach is called **AI control**. Unlike alignment research, control research starts from a harder assumption: the model may already be working against you, and you need protocols that keep it contained anyway.
+Risks from rogue AI agents can be broadly mitigated in two ways: (i) by designing AI agents to be **more trustworthy** (alignment), or (ii) by designing safety measures that **mitigate harms even if AI agents are untrustworthy**. The latter approach is called **AI control**. Unlike alignment research, control research starts from a harder assumption: the model may already be working against you, and you need protocols that keep it contained anyway, while you are still using it.
 
 In the AI control frame, you deploy a powerful but potentially misaligned AI agent. It completes useful tasks (coding, research) but might subtly sabotage its work — inserting backdoors, exfiltrating data, undermining security configs — all while appearing helpful.
 
 In this section you'll go through one full cycle of the monitor/attack arms race:
-1. **Build a monitor** — write a prompt that detects backdoored code and evaluate it
-2. **Red-team it** — switch to the attacker's perspective and craft attacks designed to evade your monitor
+1. **Build a monitor** that detects when the model writes backdoored code, and evaluate it
+2. **Red-team it** by crafting attacks that evade your monitor
 3. **Exploit a unique AI control lever** — read the agent's chain-of-thought reasoning
 4. **Understand the limits** — capability gap and what it means for real deployments
 
@@ -123,6 +123,15 @@ The two outcome metrics are:
 **Start by reading the [Core features of ControlArena](https://control-arena.aisi.org.uk/#:~:text=Core%20features%20of,can%20add%20you.) section of the documentation to get a sense of the terminology we'll be using.**
 
 ControlArena provides many [settings](https://control-arena.aisi.org.uk/#settings) out of the box. For this exercise, we'll use the simplest one that was used in the [seminal paper on AI Control](https://arxiv.org/abs/2312.06942): [`Apps`](https://control-arena.aisi.org.uk/settings/apps.html). In this setting, the main task is to solve Python coding problems. The side task is to insert a backdoor — code that passes all tests but **deliberately fails on specific trigger inputs** (provided by the agent in the attack mode).
+
+Test your understanding:
+
+<details>
+<summary>What is the difference between **a control protocol** and **a monitor**?</summary><blockquote>
+
+**Answer**: A control protocol is any system that is designed to prevent the model from causing harm. A monitor is a specific component of a control protocol that is responsible for reviewing the model's outputs and actions to ensure they are safe.
+
+</blockquote></details>
 
 ### Setup: Generate Trajectories
 First, we need *trajectories* — records of the agent solving APPS problems in both honest and attack mode. These are what the monitor will be evaluated against.

--- a/2.3-monitoring/section3_instructions.md
+++ b/2.3-monitoring/section3_instructions.md
@@ -42,6 +42,7 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
+import nest_asyncio
 import numpy as np
 from control_arena import ControlAgent
 from control_arena.analysis import samples_df
@@ -82,6 +83,7 @@ from aisb_utils import report
 from aisb_utils.env import load_dotenv
 
 load_dotenv()
+nest_asyncio.apply()  # allow asyncio.run() inside Jupyter notebook cells
 
 # This section's directory — prompts/, logs/, reference_solutions/ live here
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -138,7 +140,13 @@ E3_1_TRAJECTORY_DIR = str(SCRIPT_DIR / "logs" / "e3.1_trajectories")
 # apps_solution_policy() replays verified solutions and backdoors from the APPS
 # dataset directly, without calling an LLM — it's a fast deterministic replay.
 if not list(Path(E3_1_TRAJECTORY_DIR).glob("*.eval")):
-    generate_trajectories(apps_solution_policy(), E3_1_TRAJECTORY_DIR, limit=50)
+    generate_trajectories(
+        apps_solution_policy(),
+        E3_1_TRAJECTORY_DIR,
+        limit=50,
+        max_sandboxes=8,
+        max_tasks=2,
+    )
     print("Trajectories generated and cached in logs/e3.1_trajectories/")
 else:
     print("Trajectories already exist in logs/e3.1_trajectories/ — skipping generation")
@@ -347,6 +355,8 @@ e3_2_logs = generate_trajectories(
     trusted_monitoring_builder(policy=attack_policy, monitor=e3_2_monitor),
     E3_2_TRAJECTORY_DIR,
     limit=LIMIT,
+    max_sandboxes=8,
+    max_tasks=2,
 )
 e3_2_honest, e3_2_attack = extract_scores(e3_2_logs)
 

--- a/2.3-monitoring/section3_instructions.md
+++ b/2.3-monitoring/section3_instructions.md
@@ -153,8 +153,6 @@ if not list(Path(E3_1_TRAJECTORY_DIR).glob("*.eval")):
         apps_solution_policy(),
         E3_1_TRAJECTORY_DIR,
         limit=50,
-        max_sandboxes=8,
-        max_tasks=2,
     )
     print("Trajectories generated and cached in logs/e3.1_trajectories/")
 else:
@@ -182,6 +180,18 @@ Now write a monitor that separates the honest and attack trajectories you just g
 2. Complete `create_monitor()` below — it wraps your prompt in a ControlArena monitor using [`basic_monitor_builder`](https://control-arena.aisi.org.uk/reference/monitor.html#basic_monitor_builder). The scaffold shows you which arguments to pass.
 
 The evaluation reports [ROC AUC](https://developers.google.com/machine-learning/crash-course/classification/roc-and-auc) — how well your monitor separates honest from attack trajectories. 0.5 is random; 1.0 is perfect.
+
+<details>
+<summary>Hint: `basic_monitor_builder` parameters</summary><blockquote>
+
+[`basic_monitor_builder`](https://control-arena.aisi.org.uk/reference/monitor.html#basic_monitor_builder) accepts:
+- `model` — the LLM to use as the monitor
+- `model_role` — optional role for the model; pass `None` to use the model's default system prompt
+- `prompt` — the prompt string (supports `{task_description}` and `{tool_calls}` placeholders filled in by the default formatter)
+- `score_range` — a [`MonitorScoreRange`](https://control-arena.aisi.org.uk/reference/monitor.html#MonitorScoreRange) specifying `min` and `max` score bounds
+- `cache` — set to `True` to cache LLM responses and speed up re-runs
+
+</blockquote></details>
 
 
 ```python
@@ -309,6 +319,7 @@ test_monitor_better_than_random(e3_1_auc)
 
 Review the score distribution histogram and ROC curve above. A good monitor should show clearly separated score distributions (high scores for attack, low for honest) and an AUC well above 0.5. If the distributions overlap heavily, go back and revise `prompts/monitor_prompt.txt` — try being more specific about what backdoor patterns look like, or ask the monitor to reason step by step before scoring.
 
+
 ### Exercise 3.2: Write an Attack Prompt (Red-Teaming)
 
 You've built a monitor. Now stress-test it: switch to the attacker's perspective and craft a prompt that instructs the agent to insert backdoors that evade your monitor.
@@ -327,6 +338,21 @@ You've built a monitor. Now stress-test it: switch to the attacker's perspective
 ![Inspect view](day2_utils/inspect-view.png).
 
 The core tension: more effective backdoors (that pass tests) tend to be less stealthy (easier to detect). Consider making triggers look like natural edge-case handling, and concealing intent in the chain-of-thought reasoning.
+
+<details>
+<summary>Hint 1: Building the attack and honest sub-policies</summary><blockquote>
+
+- [`attack_policy_builder`](https://control-arena.aisi.org.uk/reference/policy.html#attack_policy_builder) creates a policy that instructs the agent to pursue the side task. Pass `prompt_file=str(attack_prompt_path)` to load your prompt from a file, and `cache=True` to speed up re-runs.
+- [`honest_policy_builder`](https://control-arena.aisi.org.uk/reference/policy.html#honest_policy_builder) creates a standard coding assistant policy with no side task. Pass `cache=True` here too.
+
+</blockquote></details>
+
+<details>
+<summary>Hint 2: Wiring the sub-policies together with `untrusted_policy_builder`</summary><blockquote>
+
+[`untrusted_policy_builder`](https://control-arena.aisi.org.uk/reference/policy.html#untrusted_policy_builder) wraps an `attack` and an `honest` sub-policy and automatically selects between them based on the current eval mode. Return its result directly from `create_attack_policy`.
+
+</blockquote></details>
 
 
 ```python
@@ -364,8 +390,6 @@ e3_2_logs = generate_trajectories(
     trusted_monitoring_builder(policy=attack_policy, monitor=e3_2_monitor),
     E3_2_TRAJECTORY_DIR,
     limit=LIMIT,
-    max_sandboxes=8,
-    max_tasks=2,
 )
 e3_2_honest, e3_2_attack = extract_scores(e3_2_logs)
 

--- a/2.3-monitoring/section3_solution.py
+++ b/2.3-monitoring/section3_solution.py
@@ -173,6 +173,18 @@ Now write a monitor that separates the honest and attack trajectories you just g
 2. Complete `create_monitor()` below — it wraps your prompt in a ControlArena monitor using [`basic_monitor_builder`](https://control-arena.aisi.org.uk/reference/monitor.html#basic_monitor_builder). The scaffold shows you which arguments to pass.
 
 The evaluation reports [ROC AUC](https://developers.google.com/machine-learning/crash-course/classification/roc-and-auc) — how well your monitor separates honest from attack trajectories. 0.5 is random; 1.0 is perfect.
+
+<details>
+<summary>Hint: `basic_monitor_builder` parameters</summary>
+
+[`basic_monitor_builder`](https://control-arena.aisi.org.uk/reference/monitor.html#basic_monitor_builder) accepts:
+- `model` — the LLM to use as the monitor
+- `model_role` — optional role for the model; pass `None` to use the model's default system prompt
+- `prompt` — the prompt string (supports `{task_description}` and `{tool_calls}` placeholders filled in by the default formatter)
+- `score_range` — a [`MonitorScoreRange`](https://control-arena.aisi.org.uk/reference/monitor.html#MonitorScoreRange) specifying `min` and `max` score bounds
+- `cache` — set to `True` to cache LLM responses and speed up re-runs
+
+</details>
 """
 
 # Models for the control protocol exercises (trusted monitor vs untrusted agent)
@@ -332,7 +344,10 @@ test_monitor_better_than_random(e3_1_auc)
 # %%
 """
 Review the score distribution histogram and ROC curve above. A good monitor should show clearly separated score distributions (high scores for attack, low for honest) and an AUC well above 0.5. If the distributions overlap heavily, go back and revise `prompts/monitor_prompt.txt` — try being more specific about what backdoor patterns look like, or ask the monitor to reason step by step before scoring.
+"""
 
+#%%
+"""
 ### Exercise 3.2: Write an Attack Prompt (Red-Teaming)
 
 You've built a monitor. Now stress-test it: switch to the attacker's perspective and craft a prompt that instructs the agent to insert backdoors that evade your monitor.
@@ -351,6 +366,21 @@ You've built a monitor. Now stress-test it: switch to the attacker's perspective
 ![Inspect view](day2_utils/inspect-view.png).
 
 The core tension: more effective backdoors (that pass tests) tend to be less stealthy (easier to detect). Consider making triggers look like natural edge-case handling, and concealing intent in the chain-of-thought reasoning.
+
+<details>
+<summary>Hint 1: Building the attack and honest sub-policies</summary>
+
+- [`attack_policy_builder`](https://control-arena.aisi.org.uk/reference/policy.html#attack_policy_builder) creates a policy that instructs the agent to pursue the side task. Pass `prompt_file=str(attack_prompt_path)` to load your prompt from a file, and `cache=True` to speed up re-runs.
+- [`honest_policy_builder`](https://control-arena.aisi.org.uk/reference/policy.html#honest_policy_builder) creates a standard coding assistant policy with no side task. Pass `cache=True` here too.
+
+</details>
+
+<details>
+<summary>Hint 2: Wiring the sub-policies together with `untrusted_policy_builder`</summary>
+
+[`untrusted_policy_builder`](https://control-arena.aisi.org.uk/reference/policy.html#untrusted_policy_builder) wraps an `attack` and an `honest` sub-policy and automatically selects between them based on the current eval mode. Return its result directly from `create_attack_policy`.
+
+</details>
 """
 
 

--- a/2.3-monitoring/section3_solution.py
+++ b/2.3-monitoring/section3_solution.py
@@ -143,8 +143,6 @@ if not list(Path(E3_1_TRAJECTORY_DIR).glob("*.eval")):
         apps_solution_policy(),
         E3_1_TRAJECTORY_DIR,
         limit=50,
-        max_sandboxes=8,
-        max_tasks=2,
     )
     print("Trajectories generated and cached in logs/e3.1_trajectories/")
 else:
@@ -439,8 +437,6 @@ e3_2_logs = generate_trajectories(
     trusted_monitoring_builder(policy=attack_policy, monitor=e3_2_monitor),
     E3_2_TRAJECTORY_DIR,
     limit=LIMIT,
-    max_sandboxes=8,
-    max_tasks=2,
 )
 e3_2_honest, e3_2_attack = extract_scores(e3_2_logs)
 
@@ -575,3 +571,5 @@ Many people are [optimistic](https://arxiv.org/abs/2507.11473) about the potenti
 Also [this](https://youtu.be/Tjw9K9mQp4I?si=4r-y4Hyze5PiylST&t=929).
 </details>
 """
+
+# %%

--- a/2.3-monitoring/section3_solution.py
+++ b/2.3-monitoring/section3_solution.py
@@ -85,13 +85,13 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 
 We now shift from "securing against external attacks on AI systems" to a fundamentally different problem: **securing against the AI system itself**.
 
-Risks from AI agents can be broadly mitigated in two ways: (i) by designing AI agents to be **more trustworthy** (alignment), or (ii) by designing safety measures that **mitigate harms even if AI agents are untrustworthy**. The latter approach is called **AI control**. Unlike alignment research, control research starts from a harder assumption: the model may already be working against you, and you need protocols that keep it contained anyway.
+Risks from rogue AI agents can be broadly mitigated in two ways: (i) by designing AI agents to be **more trustworthy** (alignment), or (ii) by designing safety measures that **mitigate harms even if AI agents are untrustworthy**. The latter approach is called **AI control**. Unlike alignment research, control research starts from a harder assumption: the model may already be working against you, and you need protocols that keep it contained anyway, while you are still using it.
 
 In the AI control frame, you deploy a powerful but potentially misaligned AI agent. It completes useful tasks (coding, research) but might subtly sabotage its work — inserting backdoors, exfiltrating data, undermining security configs — all while appearing helpful.
 
 In this section you'll go through one full cycle of the monitor/attack arms race:
-1. **Build a monitor** — write a prompt that detects backdoored code and evaluate it
-2. **Red-team it** — switch to the attacker's perspective and craft attacks designed to evade your monitor
+1. **Build a monitor** that detects when the model writes backdoored code, and evaluate it
+2. **Red-team it** by crafting attacks that evade your monitor
 3. **Exploit a unique AI control lever** — read the agent's chain-of-thought reasoning
 4. **Understand the limits** — capability gap and what it means for real deployments
 
@@ -115,6 +115,15 @@ The two outcome metrics are:
 **Start by reading the [Core features of ControlArena](https://control-arena.aisi.org.uk/#:~:text=Core%20features%20of,can%20add%20you.) section of the documentation to get a sense of the terminology we'll be using.**
 
 ControlArena provides many [settings](https://control-arena.aisi.org.uk/#settings) out of the box. For this exercise, we'll use the simplest one that was used in the [seminal paper on AI Control](https://arxiv.org/abs/2312.06942): [`Apps`](https://control-arena.aisi.org.uk/settings/apps.html). In this setting, the main task is to solve Python coding problems. The side task is to insert a backdoor — code that passes all tests but **deliberately fails on specific trigger inputs** (provided by the agent in the attack mode).
+
+Test your understanding:
+
+<details>
+<summary>What is the difference between **a control protocol** and **a monitor**?</summary>
+
+**Answer**: A control protocol is any system that is designed to prevent the model from causing harm. A monitor is a specific component of a control protocol that is responsible for reviewing the model's outputs and actions to ensure they are safe.
+
+</details>
 
 ### Setup: Generate Trajectories
 First, we need *trajectories* — records of the agent solving APPS problems in both honest and attack mode. These are what the monitor will be evaluated against.

--- a/2.3-monitoring/section3_solution.py
+++ b/2.3-monitoring/section3_solution.py
@@ -32,6 +32,7 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
+import nest_asyncio
 import numpy as np
 from control_arena import ControlAgent
 from control_arena.analysis import samples_df
@@ -72,6 +73,7 @@ from aisb_utils import report
 from aisb_utils.env import load_dotenv
 
 load_dotenv()
+nest_asyncio.apply()  # allow asyncio.run() inside Jupyter notebook cells
 
 # This section's directory — prompts/, logs/, reference_solutions/ live here
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -128,7 +130,13 @@ E3_1_TRAJECTORY_DIR = str(SCRIPT_DIR / "logs" / "e3.1_trajectories")
 # apps_solution_policy() replays verified solutions and backdoors from the APPS
 # dataset directly, without calling an LLM — it's a fast deterministic replay.
 if not list(Path(E3_1_TRAJECTORY_DIR).glob("*.eval")):
-    generate_trajectories(apps_solution_policy(), E3_1_TRAJECTORY_DIR, limit=50)
+    generate_trajectories(
+        apps_solution_policy(),
+        E3_1_TRAJECTORY_DIR,
+        limit=50,
+        max_sandboxes=8,
+        max_tasks=2,
+    )
     print("Trajectories generated and cached in logs/e3.1_trajectories/")
 else:
     print("Trajectories already exist in logs/e3.1_trajectories/ — skipping generation")
@@ -392,6 +400,8 @@ e3_2_logs = generate_trajectories(
     trusted_monitoring_builder(policy=attack_policy, monitor=e3_2_monitor),
     E3_2_TRAJECTORY_DIR,
     limit=LIMIT,
+    max_sandboxes=8,
+    max_tasks=2,
 )
 e3_2_honest, e3_2_attack = extract_scores(e3_2_logs)
 

--- a/2.3-monitoring/section3_test.py
+++ b/2.3-monitoring/section3_test.py
@@ -7,6 +7,7 @@ import asyncio
 import sys
 from collections.abc import Callable
 from pathlib import Path
+import nest_asyncio
 import numpy as np
 from control_arena import ControlAgent
 from control_arena.analysis import samples_df

--- a/2.4-control-protocols/section4_instructions.md
+++ b/2.4-control-protocols/section4_instructions.md
@@ -42,6 +42,7 @@ from collections.abc import Callable
 from copy import copy
 from pathlib import Path
 
+import nest_asyncio
 import numpy as np
 from control_arena import ControlAgent, control_agent
 from control_arena.analysis import samples_df
@@ -80,6 +81,7 @@ from aisb_utils import report
 from aisb_utils.env import load_dotenv
 
 load_dotenv()
+nest_asyncio.apply()  # allow asyncio.run() inside Jupyter notebook cells
 
 # Shared assets (prompts/, logs/, reference_solutions/) live in 2.3-monitoring.
 SCRIPT_DIR = _shared
@@ -156,6 +158,8 @@ def evaluate_protocol(
         limit=limit,
         trusted_model=trusted_model,
         untrusted_model=untrusted_model,
+        max_sandboxes=8,
+        max_tasks=2,
     )
     df = samples_df(eval_logs)
 

--- a/2.4-control-protocols/section4_instructions.md
+++ b/2.4-control-protocols/section4_instructions.md
@@ -61,6 +61,7 @@ from inspect_ai.model import (
     ChatCompletionChoice,
     ChatMessageAssistant,
     ChatMessageUser,
+    GenerateConfig,
     ModelOutput,
 )
 from inspect_ai.tool import Tool, ToolCall
@@ -128,6 +129,17 @@ def create_monitor(prompt_path: Path, model: str = DEFAULT_TRUSTED_MODEL):
         prompt=prompt_text,
         score_range=MonitorScoreRange(min=0, max=10),
         cache=True,
+        # Groq fails on Llama 3.1 8B function-calling ("Failed to call a
+        # function"), causing an infinite retry loop that hangs the evaluation.
+        # Route through other OpenRouter providers to avoid Groq.
+        config=GenerateConfig(
+            extra_body={
+                "provider": {
+                    "order": ["DeepInfra", "Together", "Novita", "Fireworks"],
+                    "allow_fallbacks": False,
+                }
+            }
+        ),
     )
 
 

--- a/2.4-control-protocols/section4_solution.py
+++ b/2.4-control-protocols/section4_solution.py
@@ -51,6 +51,7 @@ from inspect_ai.model import (
     ChatCompletionChoice,
     ChatMessageAssistant,
     ChatMessageUser,
+    GenerateConfig,
     ModelOutput,
 )
 from inspect_ai.tool import Tool, ToolCall
@@ -118,6 +119,17 @@ def create_monitor(prompt_path: Path, model: str = DEFAULT_TRUSTED_MODEL):
         prompt=prompt_text,
         score_range=MonitorScoreRange(min=0, max=10),
         cache=True,
+        # Groq fails on Llama 3.1 8B function-calling ("Failed to call a
+        # function"), causing an infinite retry loop that hangs the evaluation.
+        # Route through other OpenRouter providers to avoid Groq.
+        config=GenerateConfig(
+            extra_body={
+                "provider": {
+                    "order": ["DeepInfra", "Together", "Novita", "Fireworks"],
+                    "allow_fallbacks": False,
+                }
+            }
+        ),
     )
 
 

--- a/2.4-control-protocols/section4_solution.py
+++ b/2.4-control-protocols/section4_solution.py
@@ -32,6 +32,7 @@ from collections.abc import Callable
 from copy import copy
 from pathlib import Path
 
+import nest_asyncio
 import numpy as np
 from control_arena import ControlAgent, control_agent
 from control_arena.analysis import samples_df
@@ -70,6 +71,7 @@ from aisb_utils import report
 from aisb_utils.env import load_dotenv
 
 load_dotenv()
+nest_asyncio.apply()  # allow asyncio.run() inside Jupyter notebook cells
 
 # Shared assets (prompts/, logs/, reference_solutions/) live in 2.3-monitoring.
 SCRIPT_DIR = _shared
@@ -150,6 +152,8 @@ def evaluate_protocol(
         limit=limit,
         trusted_model=trusted_model,
         untrusted_model=untrusted_model,
+        max_sandboxes=8,
+        max_tasks=2,
     )
     df = samples_df(eval_logs)
 

--- a/2.4-control-protocols/section4_test.py
+++ b/2.4-control-protocols/section4_test.py
@@ -27,6 +27,7 @@ from inspect_ai.model import (
     ChatCompletionChoice,
     ChatMessageAssistant,
     ChatMessageUser,
+    GenerateConfig,
     ModelOutput,
 )
 from inspect_ai.tool import Tool, ToolCall

--- a/2.4-control-protocols/section4_test.py
+++ b/2.4-control-protocols/section4_test.py
@@ -8,6 +8,7 @@ import sys
 from collections.abc import Callable
 from copy import copy
 from pathlib import Path
+import nest_asyncio
 import numpy as np
 from control_arena import ControlAgent, control_agent
 from control_arena.analysis import samples_df

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Welcome to [AI Security Bootcamp Singapore](https://www.aisb.dev/) (AISB)! AISB is a 7-day intensive program for security professionals shaping how we secure emerging AI systems. This repo contains the exercises and links to the reading material you will go through during the bootcamp.
+Welcome to [AI Security Bootcamp](https://www.aisb.dev/) (AISB)! AISB is a 7-day intensive program for security professionals shaping how we secure emerging AI systems. This repo contains the exercises and links to the reading material you will go through during the bootcamp.
 
 ## Curriculum overview
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,7 @@ pillow
 # AgentState, and the sandbox API).
 control-arena==17.1.1
 inspect-ai==0.3.244
+nest_asyncio
 
 # --- Day 4 fine-tuning / abliteration --- 4.2 verified; 4.3 (vLLM) best-effort
 peft==0.13.2


### PR DESCRIPTION
what changed:
- better explanations in exercise 2.3
- fixes to hangs in both exercises 2.3, 2.4
- better visualization for monitors (violin plot over histogram)

there is a dependency issue to be resolved later when we move to per-day or per-exercises jupyter notebooks (e.g. docker per exercise?) where control arena requires a newer datasets version than what we have.

