### PR TITLE
fix: day0 fixes

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1.6.3": {
+      "version": "1.6.3",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:d01125a5d73422b3a5621c3dfe3dce8832a92396ccde303bb86e5622de316e98",
+      "integrity": "sha256:d01125a5d73422b3a5621c3dfe3dce8832a92396ccde303bb86e5622de316e98"
+    }
+  }
+}

--- a/day0-setup/day0_test.py
+++ b/day0-setup/day0_test.py
@@ -127,7 +127,7 @@ def test_prerequisites():
     # Check Python packages
     def check_required_packages() -> bool:
         """Check if Python packages are installed."""
-        required_packages = ["requests", "cryptography"]
+        required_packages = ["requests"]
         for package in required_packages:
             try:
                 importlib.import_module(package)

--- a/requirements-vllm.txt
+++ b/requirements-vllm.txt
@@ -1,0 +1,16 @@
+# Day 4.4 (optional) safety-finetuning inference — LoRA adapter comparison.
+#
+# vLLM has no prebuilt wheel for many hosts (e.g. aarch64/Apple Silicon
+# devcontainers) and its setup.py aborts the build if it can't detect CUDA,
+# ROCm, Neuron, or OpenVINO. It also needs a GPU to be useful at all, so this
+# is kept out of the main requirements.txt install so a missing/unbuildable
+# vLLM never blocks Day 0 setup. Install it only if you're doing Section 4.4
+# on a CUDA machine, into a CLEAN virtualenv separate from requirements.txt
+# (it targets torch 2.4, same as the main pin, but keeping it isolated avoids
+# any resolver conflicts):
+#
+#   python -m venv .venv-vllm
+#   source .venv-vllm/bin/activate
+#   pip install -r requirements-vllm.txt --extra-index-url https://download.pytorch.org/whl/cu124
+#
+vllm==0.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,9 +57,8 @@ inspect-ai==0.3.244
 
 # --- Day 4 fine-tuning --- 4.2 verified; optional 4.4 best-effort
 peft==0.13.2
-# vLLM is torch-version-sensitive; 0.6.3 targets torch 2.4. Needed only by 4.4.
-# If it conflicts with the torch pin above, install it in a separate env.
-vllm==0.6.3
+# vLLM (needed only by optional Section 4.4) is intentionally not pinned here:
+# see requirements-vllm.txt for why and how to install it separately.
 
 # --- Day 6 optional watermarking (6.4) --- best-effort
 # The latest diffusers is incompatible with torch 2.4's custom-op schema; 0.31.0


### PR DESCRIPTION
Changes:

- remove `cryptography` from required packages in the test. I looked it up everywhere and couldn't find any reference. Otherwise tests break. 
- moved `vllm` from the main `requirements.txt` to a separate one, following the previous `requirement-control-arena.txt` pattern. With `vllm` in the main file, install breaks on Mac. This is me operating under assumption that vLLM won't be needed for tasks involving dev container / local machine. 
- nit: commit devcontainer feature lock. Everyone will generate one so it's better to commit it. It doesn't add much since the version is pinned but it pre-computes integrity. 