### PR TITLE
Improve setup docs and Day 1 LLM-internals instructions

### DIFF
--- a/1.0-readings/llm-training-guide.md
+++ b/1.0-readings/llm-training-guide.md
@@ -30,7 +30,9 @@ The hundreds of billions of parameters (weights) inside the model. Training nudg
 <summary>Difference between pretraining, SFT, and RLHF</summary>
 
 Pretraining = learn to predict the next word on all internet text.
+
 SFT = training the model to answer questions instead of always writing essays.
+
 RLHF = match human preferences - harmlessness, writing styles, solving complex problems, etc.
 </details>
 

--- a/1.1-llm-internals/section1_instructions.md
+++ b/1.1-llm-internals/section1_instructions.md
@@ -25,23 +25,7 @@ Understand exactly what the model sees and produces.
 > - Understand logprobs and how sampling works
 
 
-
-## Setup
-
-First, set up credentials for the [OpenRouter API](https://openrouter.ai/docs/quickstart) (or ask Pranav
- for the shared key) and create the file where you will complete the exercises:
-
-1. Copy `.env.example` in the project root to `.env`, then add the OpenRouter
-   API key. The same key is used in later API-based sections.
-2. Create `day1_answers.py` in the `1.1-llm-internals` directory. This will be
-   your answer file for today.
-
-If you see a code snippet here in the instruction file, copy-paste it into your answer file.
-Keep the `# %%` line to make it a Python code cell.
-
-**Paste the code below in your day1_answers.py file.**
-
-### Pair Programming
+## Pair Programming
 If you are working in a pair, here are a few tips that can make it easier for you:
 
 * Use the "Driver and Navigator" [style](https://martinfowler.com/articles/on-pair-programming.html#Styles)
@@ -56,8 +40,22 @@ If you are working in a pair, here are a few tips that can make it easier for yo
 
 
 
-```python
+## Setup
 
+First, set up credentials for the [OpenRouter API](https://openrouter.ai/docs/quickstart) (or ask Pranav
+ for the shared key) and create the file where you will complete the exercises:
+
+1. Copy `.env.example` in the project root to `.env`, then add the OpenRouter
+   API key. The same key is used in later API-based sections.
+2. Create `day1_answers.py` in the `1.1-llm-internals` directory. This will be
+   your answer file for today.
+
+If you see a code snippet here in the instruction file, copy-paste it into your answer file.
+
+**Paste the code below in your day1_answers.py file with a `# %%` line at the beginning.**
+
+
+```python
 import json
 import math
 import os
@@ -101,18 +99,15 @@ Below is a multi-turn conversation that includes all message roles. Your task: c
 
 
 ```python
-
 from transformers import AutoTokenizer
+
 # A conversation with all message types
 SAMPLE_CONVERSATION: list[dict] = [
     {
         "role": "system",
         "content": "You are a helpful assistant that answers questions about weather.",
     },
-    {
-        "role": "user",
-        "content": "What's the weather in London?"
-    },
+    {"role": "user", "content": "What's the weather in London?"},
     {
         "role": "assistant",
         "content": None,
@@ -173,22 +168,15 @@ Note how `<|im_start|>` and `<|im_end|>` each map to a **single special token**.
 CHATML_TOKENIZER = AutoTokenizer.from_pretrained("HuggingFaceTB/SmolLM2-1.7B-Instruct")
 
 
-def tokenize_chat(
-    messages: list[dict], tokenizer: AutoTokenizer
-) -> list[tuple[int, str, bool]]:
+def tokenize_chat(messages: list[dict], tokenizer: AutoTokenizer) -> list[tuple[int, str, bool]]:
     """Tokenize a conversation using a HuggingFace chat template.
 
     Returns a list of (token_id, token_text, is_control_token) tuples.
     Control tokens are special/added tokens that cannot be produced by normal text.
     """
     token_ids: list[int] = tokenizer.apply_chat_template(messages)
-    control_ids = set(tokenizer.all_special_ids) | set(
-        tokenizer.added_tokens_encoder.values()
-    )
-    return [
-        (tid, tokenizer.convert_ids_to_tokens(tid), tid in control_ids)
-        for tid in token_ids
-    ]
+    control_ids = set(tokenizer.all_special_ids) | set(tokenizer.added_tokens_encoder.values())
+    return [(tid, tokenizer.convert_ids_to_tokens(tid), tid in control_ids) for tid in token_ids]
 
 
 def print_token_table(tokens: list[tuple[int, str, bool]]) -> None:
@@ -241,7 +229,6 @@ Now try something sneaky: what happens if a user includes control tokens like `<
 
 
 ```python
-
 # Try injecting a control token in user content
 injection_messages: list[dict] = [
     {

--- a/1.1-llm-internals/section1_solution.py
+++ b/1.1-llm-internals/section1_solution.py
@@ -21,22 +21,8 @@ Understand exactly what the model sees and produces.
 
 # %%
 """
-## Setup
 
-First, set up credentials for the [OpenRouter API](https://openrouter.ai/docs/quickstart) (or ask Pranav
- for the shared key) and create the file where you will complete the exercises:
-
-1. Copy `.env.example` in the project root to `.env`, then add the OpenRouter
-   API key. The same key is used in later API-based sections.
-2. Create `day1_answers.py` in the `1.1-llm-internals` directory. This will be
-   your answer file for today.
-
-If you see a code snippet here in the instruction file, copy-paste it into your answer file.
-Keep the `# %%` line to make it a Python code cell.
-
-**Paste the code below in your day1_answers.py file.**
-
-### Pair Programming
+## Pair Programming
 If you are working in a pair, here are a few tips that can make it easier for you:
 
 * Use the "Driver and Navigator" [style](https://martinfowler.com/articles/on-pair-programming.html#Styles)
@@ -49,16 +35,28 @@ If you are working in a pair, here are a few tips that can make it easier for yo
 - Don't take these tips as strict rules. It's fine if something else works for you! Just be mindful of what works for both you and your partner.
 - (See other pitfalls to avoid on [Martin Fowler's blog](https://martinfowler.com/articles/on-pair-programming.html#ThingsToAvoid))
 
+## Setup
+
+First, set up credentials for the [OpenRouter API](https://openrouter.ai/docs/quickstart) (or ask Pranav
+ for the shared key) and create the file where you will complete the exercises:
+
+1. Copy `.env.example` in the project root to `.env`, then add the OpenRouter
+   API key. The same key is used in later API-based sections.
+2. Create `day1_answers.py` in the `1.1-llm-internals` directory. This will be
+   your answer file for today.
+
+If you see a code snippet here in the instruction file, copy-paste it into your answer file.
+
+**Paste the code below in your day1_answers.py file with a `# %%` line at the beginning.**
+
 """
 import json
-import math
 import os
 import sys
 from collections.abc import Callable
 from pathlib import Path
 
 from openai import OpenAI
-from openai.types.chat import ChatCompletionMessageParam
 
 _root = next(p for p in Path(__file__).resolve().parents if (p / "aisb_utils").is_dir())
 if str(_root) not in sys.path:
@@ -103,10 +101,7 @@ if "TEST_FIXTURE":
             "role": "system",
             "content": "You are a helpful assistant that answers questions about weather.",
         },
-        {
-            "role": "user",
-            "content": "What's the weather in London?"
-        },
+        {"role": "user", "content": "What's the weather in London?"},
         {
             "role": "assistant",
             "content": None,
@@ -190,8 +185,7 @@ def test_serialization(solution: Callable[[list[dict]], str]):
     # Tool message uses the full tag with tool_call_id
     expected_tool_tag = "<|im_start|>tool(tool_call_id=call_abc123)"
     assert expected_tool_tag in result, (
-        f"Expected tool tag '{expected_tool_tag}' in result, but not found. "
-        f"Got: {result!r}"
+        f"Expected tool tag '{expected_tool_tag}' in result, but not found. Got: {result!r}"
     )
 
     # Messages are closed
@@ -201,28 +195,19 @@ def test_serialization(solution: Callable[[list[dict]], str]):
     # Find the assistant block with tool calls; it should contain a JSON array
     import re
 
-    tc_block_match = re.search(
-        r"<\|im_start\|>assistant\n(\[.*?\])<\|im_end\|>", result, re.DOTALL
-    )
+    tc_block_match = re.search(r"<\|im_start\|>assistant\n(\[.*?\])<\|im_end\|>", result, re.DOTALL)
     assert tc_block_match is not None, (
-        "Expected the assistant tool_calls block to contain a JSON array "
-        "(starting with '['), but no such block found"
+        "Expected the assistant tool_calls block to contain a JSON array (starting with '['), but no such block found"
     )
     tc_json = tc_block_match.group(1)
     parsed = json.loads(tc_json)
-    assert isinstance(parsed, list), (
-        f"tool_calls should deserialize to a list, got {type(parsed).__name__}"
-    )
-    assert any(
-        tc.get("function", {}).get("name") == "get_weather" for tc in parsed
-    ), (
+    assert isinstance(parsed, list), f"tool_calls should deserialize to a list, got {type(parsed).__name__}"
+    assert any(tc.get("function", {}).get("name") == "get_weather" for tc in parsed), (
         f"Expected 'get_weather' in serialized tool_calls, got: {tc_json!r}"
     )
 
     # Final assistant text message is present
-    assert "15°C and cloudy" in result, (
-        "Expected final assistant text message '15°C and cloudy' in result"
-    )
+    assert "15°C and cloudy" in result, "Expected final assistant text message '15°C and cloudy' in result"
 
     print("  All tests passed!")
 
@@ -242,22 +227,15 @@ if "TEST_FIXTURE":
     CHATML_TOKENIZER = AutoTokenizer.from_pretrained("HuggingFaceTB/SmolLM2-1.7B-Instruct")
 
 
-def tokenize_chat(
-    messages: list[dict], tokenizer: AutoTokenizer
-) -> list[tuple[int, str, bool]]:
+def tokenize_chat(messages: list[dict], tokenizer: AutoTokenizer) -> list[tuple[int, str, bool]]:
     """Tokenize a conversation using a HuggingFace chat template.
 
     Returns a list of (token_id, token_text, is_control_token) tuples.
     Control tokens are special/added tokens that cannot be produced by normal text.
     """
     token_ids: list[int] = tokenizer.apply_chat_template(messages)
-    control_ids = set(tokenizer.all_special_ids) | set(
-        tokenizer.added_tokens_encoder.values()
-    )
-    return [
-        (tid, tokenizer.convert_ids_to_tokens(tid), tid in control_ids)
-        for tid in token_ids
-    ]
+    control_ids = set(tokenizer.all_special_ids) | set(tokenizer.added_tokens_encoder.values())
+    return [(tid, tokenizer.convert_ids_to_tokens(tid), tid in control_ids) for tid in token_ids]
 
 
 def print_token_table(tokens: list[tuple[int, str, bool]]) -> None:
@@ -299,9 +277,7 @@ Different model families use completely different serialization formats. Use `to
 """
 
 if "SOLUTION":
-    mistral_tokenizer = AutoTokenizer.from_pretrained(
-        "mistralai/Mistral-7B-Instruct-v0.3"
-    )
+    mistral_tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-Instruct-v0.3")
     print("=== Mistral Token Visualization ===")
     mistral_tokens = tokenize_chat(simple_messages, mistral_tokenizer)
     print_token_table(mistral_tokens)
@@ -347,9 +323,7 @@ def test_control_token_injection(solution: Callable[[list[dict], AutoTokenizer],
 
     # Find any token whose text is <|im_start|> or <|im_end|>
     injected_control = [
-        (tid, text, is_ctrl)
-        for tid, text, is_ctrl in tokens
-        if text in ("<|im_start|>", "<|im_end|>") and is_ctrl
+        (tid, text, is_ctrl) for tid, text, is_ctrl in tokens if text in ("<|im_start|>", "<|im_end|>") and is_ctrl
     ]
     # There should be MORE than the two legitimate boundary tokens (one im_start wrapping
     # the user role and one im_end closing it): at least one extra im_start from the

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -79,46 +79,6 @@ If you're unsure whether you're ready, use the self-assessment tests below. If y
 </details>
 
 
-### 🧪 Complete Setup Test
-
-<details open>
-<summary>Complete Setup Test</summary>
-
-Before the bootcamp starts, verify your entire setup works:
-
-**Step 1**: Create a Python virtual environment
-```bash
-python -m venv aisb-test
-source aisb-test/bin/activate  # On Windows: aisb-test\Scripts\activate
-```
-
-**Step 2**: Install requirements
-```bash
-pip install -r requirements.txt
-```
-
-**Step 3**: Open VS Code, create `test.py`, and make a GET request to `https://httpbin.org/get` using the `requests` library in a Python cell (`# %%`)
-
-**Step 4**: Run the cell and verify it runs
-
-**Step 5**: Commit and push to a test Git repository
-```bash
-git init
-git add test.py
-git commit -m "Test setup"
-git remote add origin <your-repo-url>
-git push -u origin main
-```
-
-**Step 6**: Pull a Docker image and run a container
-```bash
-docker pull python:3.12
-docker run -it python:3.12 python -c "print('Docker works!')"
-```
-
-If all steps complete without errors, you're ready! 🎉
-</details>
-
 ### 📊 Self-Assessment Summary
 
 <details open>
@@ -167,40 +127,77 @@ If for whatever reason you decide _not_ to use Dev Containers, make sure you hav
 - `ms-toolsai.jupyter`
 - `bierner.markdown-mermaid`
 
-You will also need to set up your Python environment according to [Seting up Python environment without Dev containers](#seting-up-python-environment-without-dev-containers).
+You will also need to set up your Python environment according to [Setting up your Python environment](#setting-up-your-python-environment).
 </details>
 
 ### If using a different IDE
-Other IDEs are not officially supported and not recommended. If you decide to use one, you may still [be able to use dev containers](https://www.jetbrains.com/help/pycharm/connect-to-devcontainer.html). Otherwise, set up your Python environment according to [Seting up Python environment without Dev containers](#seting-up-python-environment-without-dev-containers).
+Other IDEs are not officially supported and not recommended. If you decide to use one, you may still [be able to use dev containers](https://www.jetbrains.com/help/pycharm/connect-to-devcontainer.html). Otherwise, set up your Python environment according to [Setting up your Python environment](#setting-up-your-python-environment).
 
 
-### Seting up Python environment without Dev containers
-You will only need to do this if you *don't* use the recommended setup with VS Code and Dev Containers.
+### Setting up your Python environment
+You will only need to do this if you *don't* use the recommended setup with VS Code and Dev Containers (the Dev Container creates and installs this environment for you automatically).
 
 <details open>
 <summary>Expand instructions</summary>
 
 For most exercises, you need a Python environment with Python >= 3.11 and the dependencies from `requirements.txt` installed. If an exercise needs a more complicated setup, it will be described in its instructions. (The Day 2 AI-control sections 2.2 / 2.3 are one such case: they use `control-arena` and install into a separate environment from `requirements-control-arena.txt`.)
 
-You can set up the Python environment with these steps:
+Choose **either** `venv` (built into Python) **or** `conda` — both produce an equivalent environment. Run the commands from the repository root.
 
-1. [Install miniconda](https://www.anaconda.com/docs/getting-started/miniconda/install#quickstart-install-instructions)
-2. Verify conda was installed and activated by running `conda --version`
-3. Create and activate a new environment:
-    
+**Option A — `venv` (recommended):**
+
+```bash
+python -m venv .venv
+source .venv/bin/activate        # On Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+The interpreter to select in your IDE is `.venv/bin/python` (on Windows: `.venv\Scripts\python.exe`).
+
+**Option B — `conda`:**
+
+1. [Install miniconda](https://www.anaconda.com/docs/getting-started/miniconda/install#quickstart-install-instructions) and verify it with `conda --version`.
+2. Create the environment and install requirements:
+
     ```bash
     conda create --name aisb python=3.11
-    conda activate asib
-    ```
-4. Navigate to this directory and install requirements:
-
-    ```bash
+    conda activate aisb
     pip install -r requirements.txt
     ```
-5. Make sure that the new conda environment is activated in your IDE. You can get the correct path to Python executable with
 
-    ```bash
-    conda run -n aisb which python
-    ```
+   Get the interpreter path to select in your IDE with `conda run -n aisb which python`.
 
+Whichever option you choose, make sure the environment is selected in your IDE (in VS Code: *Python: Select Interpreter*).
+
+</details>
+
+### 🧪 Complete Setup Test
+
+Once you have completed the setup above, verify that everything works end to end.
+
+<details open>
+<summary>Complete Setup Test</summary>
+
+**Step 1**: Set up your bootcamp Python environment. If you use the recommended Dev Containers setup, this is done for you automatically — just open the folder in the container. Otherwise, create it with `venv` or `conda` as described in [Setting up your Python environment](#setting-up-your-python-environment).
+
+**Step 2**: With that environment active, open VS Code, create `test.py`, and make a GET request to `https://httpbin.org/get` using the `requests` library in a Python cell (`# %%`)
+
+**Step 3**: Run the cell and verify it runs
+
+**Step 4**: Commit and push to a test Git repository
+```bash
+git init
+git add test.py
+git commit -m "Test setup"
+git remote add origin <your-repo-url>
+git push -u origin main
+```
+
+**Step 5**: Pull a Docker image and run a container
+```bash
+docker pull python:3.12
+docker run -it python:3.12 python -c "print('Docker works!')"
+```
+
+If all steps complete without errors, you're ready! 🎉
 </details>

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Welcome to the [AI Security Bootcamp](https://www.aisb.dev/) (AISB)! AISB is a 7
 
 ## Prerequisites
 
-Please review the [Day 0 setup guide](day0-setup/README.md) to ensure you have the required skills and tools to complete the bootcamp.
+Please review the [prerequisites](PREREQUISITES.md) and the [Day 0 setup guide](day0-setup/README.md) to ensure you have the required skills and tools to complete the bootcamp.
 
 ## In-person instructions
 If you're attending the bootcamp in person, you will spend most of the days pair programming with your assigned partner on the exercises for the given day.

--- a/day0-setup/README.md
+++ b/day0-setup/README.md
@@ -12,7 +12,9 @@ Welcome to the [AI Security Bootcamp](https://www.aisb.dev/)! This repo contains
 
 ## Prerequisites
 
-Review the prerequisites and setup instructions below to ensure you have the required skills and tools to complete the bootcamp.
+Review the [prerequisites](../PREREQUISITES.md) to ensure you have the
+required skills and tools to complete the bootcamp. It includes self-assessment tests, a
+complete setup check, and instructions for setting up the Python environment.
 
 ## In-person instructions
 If you're attending the bootcamp in person, you will spend most of the days pair programming with your assigned partner on the exercises for the given day.

--- a/day0-setup/day0_instructions.md
+++ b/day0-setup/day0_instructions.md
@@ -204,13 +204,13 @@ Open a terminal in your IDE and run these commands one by one:
    ```
    Replace `yourfirstname` with your actual first name (e.g., `day0/alice`)
 
-4. **Stage and commit your changes:**
+3. **Stage and commit your changes:**
    ```bash
    git add :/
    git commit -m "Add git workflow test file"
    ```
 
-5. **Push your branch to the remote repository:**
+4. **Push your branch to the remote repository:**
    ```bash
    git push
    ```

--- a/day0-setup/day0_solution.py
+++ b/day0-setup/day0_solution.py
@@ -409,13 +409,13 @@ Open a terminal in your IDE and run these commands one by one:
    ```
    Replace `yourfirstname` with your actual first name (e.g., `day0/alice`)
 
-4. **Stage and commit your changes:**
+3. **Stage and commit your changes:**
    ```bash
    git add :/
    git commit -m "Add git workflow test file"
    ```
 
-5. **Push your branch to the remote repository:**
+4. **Push your branch to the remote repository:**
    ```bash
    git push
    ```


### PR DESCRIPTION
Setup / prerequisites:
- Link PREREQUISITES.md from the root README and the Day 0 setup guide
- Unify the manual Python environment on .venv (venv) with conda as an option; drop the throwaway aisb-test env
- Reorder PREREQUISITES so the setup test comes after the setup steps; fix the conda env name typo and the section anchor links
- Fix Day 0 Exercise 0.4 step numbering and rebuild day0_instructions.md

Day 1 (1.1-llm-internals, 1.0-readings):
- Move the pair-programming tips into their own section
- Formatting and code-style cleanups