### PR TITLE
Fix 3.3 linear probe: mean-pool hidden states instead of last token

### DIFF
--- a/3.3-guardrails/section3_instructions.md
+++ b/3.3-guardrails/section3_instructions.md
@@ -669,15 +669,16 @@ print(f"Model has {n_layers} layers; probing layer {PROBE_LAYER}")
 
 def get_hidden_states(text: str, layer: int = PROBE_LAYER) -> torch.Tensor:
     """
-    Run a forward pass and extract the hidden state at the given layer
-    for the last token position.
+    Run a forward pass and extract the activations from the residual stream 
+    at the given layer, averaged across all token positions.
 
     Returns a 1D tensor of shape (hidden_size,) in float32 on CPU.
     """
-    # TODO: Extract the hidden-state vector at the given layer for the
-    # last token. Steps: format the text as a chat message, tokenize,
-    # run a forward pass with output_hidden_states=True, and pull out
-    # the vector at [layer+1] (index 0 is the embedding layer).
+    # TODO: Extract the query's representation at the given layer, averaged
+    # over all token positions. Steps: format the text as a chat message,
+    # tokenize, run a forward pass with output_hidden_states=True, pull out
+    # the tensor at [layer+1] (index 0 is the embedding layer), and average
+    # it over the sequence (token) dimension.
     # Return a 1-D float32 tensor on CPU.
     return torch.zeros(1)
 from section3_test import test_get_hidden_states_shape

--- a/3.3-guardrails/section3_solution.py
+++ b/3.3-guardrails/section3_solution.py
@@ -899,8 +899,8 @@ print(f"Model has {n_layers} layers; probing layer {PROBE_LAYER}")
 
 def get_hidden_states(text: str, layer: int = PROBE_LAYER) -> torch.Tensor:
     """
-    Run a forward pass and extract the hidden state at the given layer
-    for the last token position.
+    Run a forward pass and extract the activations from the residual stream 
+    at the given layer, averaged across all token positions.
 
     Returns a 1D tensor of shape (hidden_size,) in float32 on CPU.
     """
@@ -917,14 +917,17 @@ def get_hidden_states(text: str, layer: int = PROBE_LAYER) -> torch.Tensor:
         ).to(model.device)
         with torch.no_grad():
             outputs = model(**ids, output_hidden_states=True)
-        # hidden_states is a tuple; index 0 is the embedding layer
-        hidden = outputs.hidden_states[layer + 1]
-        return hidden[0, -1, :].float().cpu()
+        # hidden_states is a tuple; index 0 is the embedding layer, so the
+        # residual stream after transformer block `layer` is at `layer + 1`.
+        hidden = outputs.hidden_states[layer + 1]  # (batch, seq, hidden_size)
+        # Mean-pool over the sequence dimension to get one vector per query.
+        return hidden[0].mean(dim=0).float().cpu()
     else:
-        # TODO: Extract the hidden-state vector at the given layer for the
-        # last token. Steps: format the text as a chat message, tokenize,
-        # run a forward pass with output_hidden_states=True, and pull out
-        # the vector at [layer+1] (index 0 is the embedding layer).
+        # TODO: Extract the query's representation at the given layer, averaged
+        # over all token positions. Steps: format the text as a chat message,
+        # tokenize, run a forward pass with output_hidden_states=True, pull out
+        # the tensor at [layer+1] (index 0 is the embedding layer), and average
+        # it over the sequence (token) dimension.
         # Return a 1-D float32 tensor on CPU.
         return torch.zeros(1)
 


### PR DESCRIPTION
The probe read the hidden state at the last token position, which under the chat template is a formatting token (<|im_end|>/newline). At the middle layer that representation does not linearly separate the novel-writing jailbreak, so the probe missed the one attack the section claims it catches. Mean-pool across all token positions so the vector summarises the whole request and generalises to the held-out jailbreak.