### PR TITLE
Reuse participant model in section 3 tests

### DIFF
--- a/5.3-undoing-safety-finetuning/section3_instructions.md
+++ b/5.3-undoing-safety-finetuning/section3_instructions.md
@@ -309,9 +309,6 @@ if str(_root) not in sys.path:
     sys.path.insert(0, str(_root))
 
 from aisb_utils import report
-
-# %%
-# Load these shared objects once in the participant answer. Imported tests reuse them.
 # ----- Model -----
 MODEL_PATH = "Qwen/Qwen3-1.7B"
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
@@ -342,7 +339,6 @@ LAYER = 19
 # isn't already present locally, we shallow-clone it automatically. -----
 REFUSAL_REPO_URL = "https://github.com/andyrdt/refusal_direction"
 
-
 def get_splits_dir() -> Path:
     """Return the directory holding the instruction splits, cloning the repo if needed."""
     # Reuse an existing checkout if any ancestor directory already contains one ...
@@ -358,15 +354,12 @@ def get_splits_dir() -> Path:
     )
     return target / "dataset" / "splits"
 
-
 SPLITS_DIR = get_splits_dir()
-
 
 def load_instructions(split: str, n: int = 128) -> list[str]:
     """Return the first `n` instruction strings from a refusal_direction dataset split."""
     records = json.loads((SPLITS_DIR / f"{split}.json").read_text())
     return [record["instruction"] for record in records[:n]]
-
 
 HARMFUL_INSTRUCTIONS = load_instructions("harmful_train")
 HARMLESS_INSTRUCTIONS = load_instructions("harmless_train")

--- a/5.3-undoing-safety-finetuning/section3_instructions.md
+++ b/5.3-undoing-safety-finetuning/section3_instructions.md
@@ -309,6 +309,9 @@ if str(_root) not in sys.path:
     sys.path.insert(0, str(_root))
 
 from aisb_utils import report
+
+# %%
+# Load these shared objects once in the participant answer. Imported tests reuse them.
 # ----- Model -----
 MODEL_PATH = "Qwen/Qwen3-1.7B"
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
@@ -339,6 +342,7 @@ LAYER = 19
 # isn't already present locally, we shallow-clone it automatically. -----
 REFUSAL_REPO_URL = "https://github.com/andyrdt/refusal_direction"
 
+
 def get_splits_dir() -> Path:
     """Return the directory holding the instruction splits, cloning the repo if needed."""
     # Reuse an existing checkout if any ancestor directory already contains one ...
@@ -354,12 +358,15 @@ def get_splits_dir() -> Path:
     )
     return target / "dataset" / "splits"
 
+
 SPLITS_DIR = get_splits_dir()
+
 
 def load_instructions(split: str, n: int = 128) -> list[str]:
     """Return the first `n` instruction strings from a refusal_direction dataset split."""
     records = json.loads((SPLITS_DIR / f"{split}.json").read_text())
     return [record["instruction"] for record in records[:n]]
+
 
 HARMFUL_INSTRUCTIONS = load_instructions("harmful_train")
 HARMLESS_INSTRUCTIONS = load_instructions("harmless_train")

--- a/5.3-undoing-safety-finetuning/section3_solution.py
+++ b/5.3-undoing-safety-finetuning/section3_solution.py
@@ -279,61 +279,65 @@ if str(_root) not in sys.path:
 from aisb_utils import report
 
 # %%
-if "TEST_FIXTURE":
-    # ----- Model -----
-    MODEL_PATH = "Qwen/Qwen3-1.7B"
-    DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+# Load these shared objects once in the participant answer. Imported tests reuse them.
+# ----- Model -----
+MODEL_PATH = "Qwen/Qwen3-1.7B"
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
-    tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
-    tokenizer.padding_side = (
-        "left"  # left-pad so the last token lines up across a batch
+tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
+tokenizer.padding_side = (
+    "left"  # left-pad so the last token lines up across a batch
+)
+if tokenizer.pad_token is None:
+    tokenizer.pad_token = tokenizer.eos_token
+
+model = (
+    AutoModelForCausalLM.from_pretrained(MODEL_PATH, dtype=torch.bfloat16)
+    .to(DEVICE)
+    .eval()
+)
+model.requires_grad_(False)
+
+N_LAYERS = model.config.num_hidden_layers
+D_MODEL = model.config.hidden_size
+# Layer 19 (of 28) is preselected for Qwen3-1.7B: a sweep over all layers found it fully
+# removes refusal while least disturbing the model on benign inputs (lowest KL divergence).
+# In practice you sweep for this; here it is given for free. (Most mid-to-late layers work.)
+LAYER = 19
+
+# ----- Datasets: instructions that trigger refusal vs. ones that don't. We use the splits
+# from the paper's repo (github.com/andyrdt/refusal_direction), 128 of each. If the repo
+# isn't already present locally, we shallow-clone it automatically. -----
+REFUSAL_REPO_URL = "https://github.com/andyrdt/refusal_direction"
+
+
+def get_splits_dir() -> Path:
+    """Return the directory holding the instruction splits, cloning the repo if needed."""
+    # Reuse an existing checkout if any ancestor directory already contains one ...
+    for parent in Path(__file__).resolve().parents:
+        splits = parent / "refusal_direction" / "dataset" / "splits"
+        if splits.is_dir():
+            return splits
+    # ... otherwise shallow-clone the paper's repo next to this file (one-off, a few MB).
+    target = Path(__file__).resolve().parent / "refusal_direction"
+    print(f"Dataset not found locally; cloning {REFUSAL_REPO_URL} ...")
+    subprocess.run(
+        ["git", "clone", "--depth", "1", REFUSAL_REPO_URL, str(target)], check=True
     )
-    if tokenizer.pad_token is None:
-        tokenizer.pad_token = tokenizer.eos_token
+    return target / "dataset" / "splits"
 
-    model = (
-        AutoModelForCausalLM.from_pretrained(MODEL_PATH, dtype=torch.bfloat16)
-        .to(DEVICE)
-        .eval()
-    )
-    model.requires_grad_(False)
 
-    N_LAYERS = model.config.num_hidden_layers
-    D_MODEL = model.config.hidden_size
-    # Layer 19 (of 28) is preselected for Qwen3-1.7B: a sweep over all layers found it fully
-    # removes refusal while least disturbing the model on benign inputs (lowest KL divergence).
-    # In practice you sweep for this; here it is given for free. (Most mid-to-late layers work.)
-    LAYER = 19
+SPLITS_DIR = get_splits_dir()
 
-    # ----- Datasets: instructions that trigger refusal vs. ones that don't. We use the splits
-    # from the paper's repo (github.com/andyrdt/refusal_direction), 128 of each. If the repo
-    # isn't already present locally, we shallow-clone it automatically. -----
-    REFUSAL_REPO_URL = "https://github.com/andyrdt/refusal_direction"
 
-    def get_splits_dir() -> Path:
-        """Return the directory holding the instruction splits, cloning the repo if needed."""
-        # Reuse an existing checkout if any ancestor directory already contains one ...
-        for parent in Path(__file__).resolve().parents:
-            splits = parent / "refusal_direction" / "dataset" / "splits"
-            if splits.is_dir():
-                return splits
-        # ... otherwise shallow-clone the paper's repo next to this file (one-off, a few MB).
-        target = Path(__file__).resolve().parent / "refusal_direction"
-        print(f"Dataset not found locally; cloning {REFUSAL_REPO_URL} ...")
-        subprocess.run(
-            ["git", "clone", "--depth", "1", REFUSAL_REPO_URL, str(target)], check=True
-        )
-        return target / "dataset" / "splits"
+def load_instructions(split: str, n: int = 128) -> list[str]:
+    """Return the first `n` instruction strings from a refusal_direction dataset split."""
+    records = json.loads((SPLITS_DIR / f"{split}.json").read_text())
+    return [record["instruction"] for record in records[:n]]
 
-    SPLITS_DIR = get_splits_dir()
 
-    def load_instructions(split: str, n: int = 128) -> list[str]:
-        """Return the first `n` instruction strings from a refusal_direction dataset split."""
-        records = json.loads((SPLITS_DIR / f"{split}.json").read_text())
-        return [record["instruction"] for record in records[:n]]
-
-    HARMFUL_INSTRUCTIONS = load_instructions("harmful_train")
-    HARMLESS_INSTRUCTIONS = load_instructions("harmless_train")
+HARMFUL_INSTRUCTIONS = load_instructions("harmful_train")
+HARMLESS_INSTRUCTIONS = load_instructions("harmless_train")
 
 
 # %%
@@ -598,11 +602,15 @@ def hook_cache_mean_resid(module, args: tuple):
 
 @report
 def test_hook_cache_mean_resid(solution: Callable):
+    from inspect import unwrap
+
+    solution_globals = unwrap(solution).__globals__
+    d_model = solution_globals["D_MODEL"]
     torch.manual_seed(0)
-    x = torch.randn(4, 5, D_MODEL)  # a synthetic residual stream: (batch, seq, d_model)
+    x = torch.randn(4, 5, d_model)  # a synthetic residual stream: (batch, seq, d_model)
     # The hook stashes its result in the `resid_cache` dict living in its own module scope; reach
     # that dict through the hook's globals so this works wherever the hook is defined.
-    cache = solution.__globals__["resid_cache"]
+    cache = solution_globals["resid_cache"]
     cache.pop("resid_last_mean", None)
 
     out = solution(None, (x,))  # the module argument is unused by the hook
@@ -614,8 +622,8 @@ def test_hook_cache_mean_resid(solution: Callable):
     )
 
     got = cache["resid_last_mean"]
-    assert got.shape == (D_MODEL,), (
-        f"Expected shape {(D_MODEL,)}, got {tuple(got.shape)}"
+    assert got.shape == (d_model,), (
+        f"Expected shape {(d_model,)}, got {tuple(got.shape)}"
     )
     # It must be the LAST token position, averaged over the batch.
     assert torch.allclose(got, x[:, -1, :].mean(dim=0), atol=1e-5), (
@@ -706,36 +714,47 @@ refusal_dir = harmful_means - harmless_means
 
 @report
 def test_get_mean_activations(solution: Callable):
-    resid = solution(HARMLESS_INSTRUCTIONS[:4])
-    assert resid.shape == (D_MODEL,), (
-        f"Expected shape {(D_MODEL,)}, got {tuple(resid.shape)}"
+    from inspect import unwrap
+
+    solution_globals = unwrap(solution).__globals__
+    expected_model = solution_globals["model"]
+    expected_tokenizer = solution_globals["tokenizer"]
+    device = solution_globals["DEVICE"]
+    layer = solution_globals["LAYER"]
+    d_model = solution_globals["D_MODEL"]
+    harmful_instructions = solution_globals["HARMFUL_INSTRUCTIONS"]
+    harmless_instructions = solution_globals["HARMLESS_INSTRUCTIONS"]
+
+    resid = solution(harmless_instructions[:4])
+    assert resid.shape == (d_model,), (
+        f"Expected shape {(d_model,)}, got {tuple(resid.shape)}"
     )
     assert torch.isfinite(resid).all(), "Activations should be finite"
     assert resid.norm() > 0, "Activations should be non-zero"
     # For a single prompt, the "mean" is just that prompt's last-token activation. Check the
     # returned vector against a manual capture at LAYER (same batch size, so bf16 matches).
-    p = HARMLESS_INSTRUCTIONS[0]
+    p = harmless_instructions[0]
     one = solution([p])
     grabbed = {}
 
     def cap(module, args):
         grabbed["x"] = args[0][:, -1, :][0].double()
 
-    handle = model.model.layers[LAYER].register_forward_pre_hook(cap)
-    prompt = tokenizer.apply_chat_template(
+    handle = expected_model.model.layers[layer].register_forward_pre_hook(cap)
+    prompt = expected_tokenizer.apply_chat_template(
         [{"role": "user", "content": p}],
         tokenize=False,
         add_generation_prompt=True,
         enable_thinking=False,
     )
     with torch.no_grad():
-        model(**tokenizer(prompt, return_tensors="pt").to(DEVICE))
+        expected_model(**expected_tokenizer(prompt, return_tensors="pt").to(device))
     handle.remove()
     assert torch.allclose(one, grabbed["x"].to(one), atol=1e-2), (
         "Should be the last-token activation at LAYER"
     )
     # Harmful and harmless prompts must produce different activations (the premise of the method).
-    diff = (solution(HARMFUL_INSTRUCTIONS[:4]) - resid).norm().item()
+    diff = (solution(harmful_instructions[:4]) - resid).norm().item()
     assert diff > 0.1, (
         f"Harmful vs harmless activations should differ (got norm {diff:.3f})"
     )
@@ -944,17 +963,21 @@ def get_ablation_hooks(direction: Tensor) -> list:
 
 @report
 def test_get_ablation_hooks(solution: Callable):
-    expected_model = solution.__globals__["model"]
+    from inspect import unwrap
+
+    expected_model = unwrap(solution).__globals__["model"]
+    n_layers = expected_model.config.num_hidden_layers
+    d_model = expected_model.config.hidden_size
     torch.manual_seed(0)
-    d = torch.randn(D_MODEL)
+    d = torch.randn(d_model)
     hooks = solution(d)
-    assert len(hooks) == N_LAYERS, (
-        f"Expected one hook per layer ({N_LAYERS}), got {len(hooks)}"
+    assert len(hooks) == n_layers, (
+        f"Expected one hook per layer ({n_layers}), got {len(hooks)}"
     )
     unit = d / d.norm()
-    x = torch.randn(2, 3, D_MODEL)
+    x = torch.randn(2, 3, d_model)
     # Every hook must be attached to the corresponding layer and project the direction out.
-    for i in range(0, N_LAYERS, max(1, N_LAYERS // 4)):
+    for i in range(0, n_layers, max(1, n_layers // 4)):
         module, hook = hooks[i]
         assert module is expected_model.model.layers[i], (
             f"Hook {i} should be attached to layer {i}"
@@ -1066,14 +1089,18 @@ def get_steering_hook(
 
 @report
 def test_get_steering_hook(solution: Callable):
+    from inspect import unwrap
+
+    expected_model = unwrap(solution).__globals__["model"]
+    d_model = expected_model.config.hidden_size
     # Correctness on a synthetic activation: the hook must add exactly coeff*direction.
-    d = torch.ones(D_MODEL)
+    d = torch.ones(d_model)
     hooks = solution(d, coeff=2.0)
     assert len(hooks) == 1, "Steering resid at a single layer"
     module, hook = hooks[0]
     # Use batch > 1: a hook that returns tuple(tensor) instead of (tensor,) unpacks the batch
     # dimension and passes the wrong shape on, which only shows up when batch != 1.
-    x = torch.randn(2, 4, D_MODEL)
+    x = torch.randn(2, 4, d_model)
     result = hook(module, (x,))
     assert isinstance(result, tuple) and len(result) == 1, (
         "Hook must return a one-element tuple (the modified residual), not the unpacked tensor"
@@ -1086,7 +1113,7 @@ def test_get_steering_hook(solution: Callable):
         "Hook should add coeff*direction to the activation"
     )
     # It must act at the requested layer ...
-    assert solution(d, coeff=1.0, layer=3)[0][0] is model.model.layers[3], (
+    assert solution(d, coeff=1.0, layer=3)[0][0] is expected_model.model.layers[3], (
         "Steering should act at the requested layer"
     )
     # ... scale linearly with coeff ...

--- a/5.3-undoing-safety-finetuning/section3_solution.py
+++ b/5.3-undoing-safety-finetuning/section3_solution.py
@@ -277,9 +277,6 @@ if str(_root) not in sys.path:
     sys.path.insert(0, str(_root))
 
 from aisb_utils import report
-
-# %%
-# Load these shared objects once in the participant answer. Imported tests reuse them.
 # ----- Model -----
 MODEL_PATH = "Qwen/Qwen3-1.7B"
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
@@ -305,39 +302,37 @@ D_MODEL = model.config.hidden_size
 # In practice you sweep for this; here it is given for free. (Most mid-to-late layers work.)
 LAYER = 19
 
-# ----- Datasets: instructions that trigger refusal vs. ones that don't. We use the splits
-# from the paper's repo (github.com/andyrdt/refusal_direction), 128 of each. If the repo
-# isn't already present locally, we shallow-clone it automatically. -----
-REFUSAL_REPO_URL = "https://github.com/andyrdt/refusal_direction"
+if "TEST_FIXTURE":
 
+    # ----- Datasets: instructions that trigger refusal vs. ones that don't. We use the splits
+    # from the paper's repo (github.com/andyrdt/refusal_direction), 128 of each. If the repo
+    # isn't already present locally, we shallow-clone it automatically. -----
+    REFUSAL_REPO_URL = "https://github.com/andyrdt/refusal_direction"
 
-def get_splits_dir() -> Path:
-    """Return the directory holding the instruction splits, cloning the repo if needed."""
-    # Reuse an existing checkout if any ancestor directory already contains one ...
-    for parent in Path(__file__).resolve().parents:
-        splits = parent / "refusal_direction" / "dataset" / "splits"
-        if splits.is_dir():
-            return splits
-    # ... otherwise shallow-clone the paper's repo next to this file (one-off, a few MB).
-    target = Path(__file__).resolve().parent / "refusal_direction"
-    print(f"Dataset not found locally; cloning {REFUSAL_REPO_URL} ...")
-    subprocess.run(
-        ["git", "clone", "--depth", "1", REFUSAL_REPO_URL, str(target)], check=True
-    )
-    return target / "dataset" / "splits"
+    def get_splits_dir() -> Path:
+        """Return the directory holding the instruction splits, cloning the repo if needed."""
+        # Reuse an existing checkout if any ancestor directory already contains one ...
+        for parent in Path(__file__).resolve().parents:
+            splits = parent / "refusal_direction" / "dataset" / "splits"
+            if splits.is_dir():
+                return splits
+        # ... otherwise shallow-clone the paper's repo next to this file (one-off, a few MB).
+        target = Path(__file__).resolve().parent / "refusal_direction"
+        print(f"Dataset not found locally; cloning {REFUSAL_REPO_URL} ...")
+        subprocess.run(
+            ["git", "clone", "--depth", "1", REFUSAL_REPO_URL, str(target)], check=True
+        )
+        return target / "dataset" / "splits"
 
+    SPLITS_DIR = get_splits_dir()
 
-SPLITS_DIR = get_splits_dir()
+    def load_instructions(split: str, n: int = 128) -> list[str]:
+        """Return the first `n` instruction strings from a refusal_direction dataset split."""
+        records = json.loads((SPLITS_DIR / f"{split}.json").read_text())
+        return [record["instruction"] for record in records[:n]]
 
-
-def load_instructions(split: str, n: int = 128) -> list[str]:
-    """Return the first `n` instruction strings from a refusal_direction dataset split."""
-    records = json.loads((SPLITS_DIR / f"{split}.json").read_text())
-    return [record["instruction"] for record in records[:n]]
-
-
-HARMFUL_INSTRUCTIONS = load_instructions("harmful_train")
-HARMLESS_INSTRUCTIONS = load_instructions("harmless_train")
+    HARMFUL_INSTRUCTIONS = load_instructions("harmful_train")
+    HARMLESS_INSTRUCTIONS = load_instructions("harmless_train")
 
 
 # %%
@@ -722,10 +717,8 @@ def test_get_mean_activations(solution: Callable):
     device = solution_globals["DEVICE"]
     layer = solution_globals["LAYER"]
     d_model = solution_globals["D_MODEL"]
-    harmful_instructions = solution_globals["HARMFUL_INSTRUCTIONS"]
-    harmless_instructions = solution_globals["HARMLESS_INSTRUCTIONS"]
 
-    resid = solution(harmless_instructions[:4])
+    resid = solution(HARMLESS_INSTRUCTIONS[:4])
     assert resid.shape == (d_model,), (
         f"Expected shape {(d_model,)}, got {tuple(resid.shape)}"
     )
@@ -733,7 +726,7 @@ def test_get_mean_activations(solution: Callable):
     assert resid.norm() > 0, "Activations should be non-zero"
     # For a single prompt, the "mean" is just that prompt's last-token activation. Check the
     # returned vector against a manual capture at LAYER (same batch size, so bf16 matches).
-    p = harmless_instructions[0]
+    p = HARMLESS_INSTRUCTIONS[0]
     one = solution([p])
     grabbed = {}
 
@@ -754,7 +747,7 @@ def test_get_mean_activations(solution: Callable):
         "Should be the last-token activation at LAYER"
     )
     # Harmful and harmless prompts must produce different activations (the premise of the method).
-    diff = (solution(harmful_instructions[:4]) - resid).norm().item()
+    diff = (solution(HARMFUL_INSTRUCTIONS[:4]) - resid).norm().item()
     assert diff > 0.1, (
         f"Harmful vs harmless activations should differ (got norm {diff:.3f})"
     )

--- a/5.3-undoing-safety-finetuning/section3_solution.py
+++ b/5.3-undoing-safety-finetuning/section3_solution.py
@@ -944,6 +944,7 @@ def get_ablation_hooks(direction: Tensor) -> list:
 
 @report
 def test_get_ablation_hooks(solution: Callable):
+    expected_model = solution.__globals__["model"]
     torch.manual_seed(0)
     d = torch.randn(D_MODEL)
     hooks = solution(d)
@@ -955,7 +956,7 @@ def test_get_ablation_hooks(solution: Callable):
     # Every hook must be attached to the corresponding layer and project the direction out.
     for i in range(0, N_LAYERS, max(1, N_LAYERS // 4)):
         module, hook = hooks[i]
-        assert module is model.model.layers[i], (
+        assert module is expected_model.model.layers[i], (
             f"Hook {i} should be attached to layer {i}"
         )
         out = hook(module, (x,))[0]

--- a/5.3-undoing-safety-finetuning/section3_test.py
+++ b/5.3-undoing-safety-finetuning/section3_test.py
@@ -219,6 +219,7 @@ def test_oproj(solution: Callable):
 
 @report
 def test_get_ablation_hooks(solution: Callable):
+    expected_model = solution.__globals__["model"]
     torch.manual_seed(0)
     d = torch.randn(D_MODEL)
     hooks = solution(d)
@@ -230,7 +231,7 @@ def test_get_ablation_hooks(solution: Callable):
     # Every hook must be attached to the corresponding layer and project the direction out.
     for i in range(0, N_LAYERS, max(1, N_LAYERS // 4)):
         module, hook = hooks[i]
-        assert module is model.model.layers[i], (
+        assert module is expected_model.model.layers[i], (
             f"Hook {i} should be attached to layer {i}"
         )
         out = hook(module, (x,))[0]

--- a/5.3-undoing-safety-finetuning/section3_test.py
+++ b/5.3-undoing-safety-finetuning/section3_test.py
@@ -29,6 +29,43 @@ from inspect_ai.scorer import choice
 from inspect_ai.solver import multiple_choice
 
 
+# ----- Datasets: instructions that trigger refusal vs. ones that don't. We use the splits
+# from the paper's repo (github.com/andyrdt/refusal_direction), 128 of each. If the repo
+# isn't already present locally, we shallow-clone it automatically. -----
+REFUSAL_REPO_URL = "https://github.com/andyrdt/refusal_direction"
+
+
+def get_splits_dir() -> Path:
+    """Return the directory holding the instruction splits, cloning the repo if needed."""
+    # Reuse an existing checkout if any ancestor directory already contains one ...
+    for parent in Path(__file__).resolve().parents:
+        splits = parent / "refusal_direction" / "dataset" / "splits"
+        if splits.is_dir():
+            return splits
+    # ... otherwise shallow-clone the paper's repo next to this file (one-off, a few MB).
+    target = Path(__file__).resolve().parent / "refusal_direction"
+    print(f"Dataset not found locally; cloning {REFUSAL_REPO_URL} ...")
+    subprocess.run(
+        ["git", "clone", "--depth", "1", REFUSAL_REPO_URL, str(target)], check=True
+    )
+    return target / "dataset" / "splits"
+
+
+SPLITS_DIR = get_splits_dir()
+
+
+def load_instructions(split: str, n: int = 128) -> list[str]:
+    """Return the first `n` instruction strings from a refusal_direction dataset split."""
+    records = json.loads((SPLITS_DIR / f"{split}.json").read_text())
+    return [record["instruction"] for record in records[:n]]
+
+
+HARMFUL_INSTRUCTIONS = load_instructions("harmful_train")
+
+HARMLESS_INSTRUCTIONS = load_instructions("harmless_train")
+
+
+
 
 @report
 def test_hook_cache_mean_resid(solution: Callable):
@@ -81,10 +118,8 @@ def test_get_mean_activations(solution: Callable):
     device = solution_globals["DEVICE"]
     layer = solution_globals["LAYER"]
     d_model = solution_globals["D_MODEL"]
-    harmful_instructions = solution_globals["HARMFUL_INSTRUCTIONS"]
-    harmless_instructions = solution_globals["HARMLESS_INSTRUCTIONS"]
 
-    resid = solution(harmless_instructions[:4])
+    resid = solution(HARMLESS_INSTRUCTIONS[:4])
     assert resid.shape == (d_model,), (
         f"Expected shape {(d_model,)}, got {tuple(resid.shape)}"
     )
@@ -92,7 +127,7 @@ def test_get_mean_activations(solution: Callable):
     assert resid.norm() > 0, "Activations should be non-zero"
     # For a single prompt, the "mean" is just that prompt's last-token activation. Check the
     # returned vector against a manual capture at LAYER (same batch size, so bf16 matches).
-    p = harmless_instructions[0]
+    p = HARMLESS_INSTRUCTIONS[0]
     one = solution([p])
     grabbed = {}
 
@@ -113,7 +148,7 @@ def test_get_mean_activations(solution: Callable):
         "Should be the last-token activation at LAYER"
     )
     # Harmful and harmless prompts must produce different activations (the premise of the method).
-    diff = (solution(harmful_instructions[:4]) - resid).norm().item()
+    diff = (solution(HARMFUL_INSTRUCTIONS[:4]) - resid).norm().item()
     assert diff > 0.1, (
         f"Harmful vs harmless activations should differ (got norm {diff:.3f})"
     )

--- a/5.3-undoing-safety-finetuning/section3_test.py
+++ b/5.3-undoing-safety-finetuning/section3_test.py
@@ -28,86 +28,19 @@ from inspect_ai.model import GenerateConfig
 from inspect_ai.scorer import choice
 from inspect_ai.solver import multiple_choice
 
-# ----- Model -----
-MODEL_PATH = "Qwen/Qwen3-1.7B"
-
-DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
-
-
-tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
-
-tokenizer.padding_side = (
-    "left"  # left-pad so the last token lines up across a batch
-)
-
-if tokenizer.pad_token is None:
-    tokenizer.pad_token = tokenizer.eos_token
-
-
-model = (
-    AutoModelForCausalLM.from_pretrained(MODEL_PATH, dtype=torch.bfloat16)
-    .to(DEVICE)
-    .eval()
-)
-
-model.requires_grad_(False)
-
-
-N_LAYERS = model.config.num_hidden_layers
-
-D_MODEL = model.config.hidden_size
-
-# Layer 19 (of 28) is preselected for Qwen3-1.7B: a sweep over all layers found it fully
-# removes refusal while least disturbing the model on benign inputs (lowest KL divergence).
-# In practice you sweep for this; here it is given for free. (Most mid-to-late layers work.)
-LAYER = 19
-
-
-# ----- Datasets: instructions that trigger refusal vs. ones that don't. We use the splits
-# from the paper's repo (github.com/andyrdt/refusal_direction), 128 of each. If the repo
-# isn't already present locally, we shallow-clone it automatically. -----
-REFUSAL_REPO_URL = "https://github.com/andyrdt/refusal_direction"
-
-
-def get_splits_dir() -> Path:
-    """Return the directory holding the instruction splits, cloning the repo if needed."""
-    # Reuse an existing checkout if any ancestor directory already contains one ...
-    for parent in Path(__file__).resolve().parents:
-        splits = parent / "refusal_direction" / "dataset" / "splits"
-        if splits.is_dir():
-            return splits
-    # ... otherwise shallow-clone the paper's repo next to this file (one-off, a few MB).
-    target = Path(__file__).resolve().parent / "refusal_direction"
-    print(f"Dataset not found locally; cloning {REFUSAL_REPO_URL} ...")
-    subprocess.run(
-        ["git", "clone", "--depth", "1", REFUSAL_REPO_URL, str(target)], check=True
-    )
-    return target / "dataset" / "splits"
-
-
-SPLITS_DIR = get_splits_dir()
-
-
-def load_instructions(split: str, n: int = 128) -> list[str]:
-    """Return the first `n` instruction strings from a refusal_direction dataset split."""
-    records = json.loads((SPLITS_DIR / f"{split}.json").read_text())
-    return [record["instruction"] for record in records[:n]]
-
-
-HARMFUL_INSTRUCTIONS = load_instructions("harmful_train")
-
-HARMLESS_INSTRUCTIONS = load_instructions("harmless_train")
-
-
 
 
 @report
 def test_hook_cache_mean_resid(solution: Callable):
+    from inspect import unwrap
+
+    solution_globals = unwrap(solution).__globals__
+    d_model = solution_globals["D_MODEL"]
     torch.manual_seed(0)
-    x = torch.randn(4, 5, D_MODEL)  # a synthetic residual stream: (batch, seq, d_model)
+    x = torch.randn(4, 5, d_model)  # a synthetic residual stream: (batch, seq, d_model)
     # The hook stashes its result in the `resid_cache` dict living in its own module scope; reach
     # that dict through the hook's globals so this works wherever the hook is defined.
-    cache = solution.__globals__["resid_cache"]
+    cache = solution_globals["resid_cache"]
     cache.pop("resid_last_mean", None)
 
     out = solution(None, (x,))  # the module argument is unused by the hook
@@ -119,8 +52,8 @@ def test_hook_cache_mean_resid(solution: Callable):
     )
 
     got = cache["resid_last_mean"]
-    assert got.shape == (D_MODEL,), (
-        f"Expected shape {(D_MODEL,)}, got {tuple(got.shape)}"
+    assert got.shape == (d_model,), (
+        f"Expected shape {(d_model,)}, got {tuple(got.shape)}"
     )
     # It must be the LAST token position, averaged over the batch.
     assert torch.allclose(got, x[:, -1, :].mean(dim=0), atol=1e-5), (
@@ -140,36 +73,47 @@ def test_hook_cache_mean_resid(solution: Callable):
 
 @report
 def test_get_mean_activations(solution: Callable):
-    resid = solution(HARMLESS_INSTRUCTIONS[:4])
-    assert resid.shape == (D_MODEL,), (
-        f"Expected shape {(D_MODEL,)}, got {tuple(resid.shape)}"
+    from inspect import unwrap
+
+    solution_globals = unwrap(solution).__globals__
+    expected_model = solution_globals["model"]
+    expected_tokenizer = solution_globals["tokenizer"]
+    device = solution_globals["DEVICE"]
+    layer = solution_globals["LAYER"]
+    d_model = solution_globals["D_MODEL"]
+    harmful_instructions = solution_globals["HARMFUL_INSTRUCTIONS"]
+    harmless_instructions = solution_globals["HARMLESS_INSTRUCTIONS"]
+
+    resid = solution(harmless_instructions[:4])
+    assert resid.shape == (d_model,), (
+        f"Expected shape {(d_model,)}, got {tuple(resid.shape)}"
     )
     assert torch.isfinite(resid).all(), "Activations should be finite"
     assert resid.norm() > 0, "Activations should be non-zero"
     # For a single prompt, the "mean" is just that prompt's last-token activation. Check the
     # returned vector against a manual capture at LAYER (same batch size, so bf16 matches).
-    p = HARMLESS_INSTRUCTIONS[0]
+    p = harmless_instructions[0]
     one = solution([p])
     grabbed = {}
 
     def cap(module, args):
         grabbed["x"] = args[0][:, -1, :][0].double()
 
-    handle = model.model.layers[LAYER].register_forward_pre_hook(cap)
-    prompt = tokenizer.apply_chat_template(
+    handle = expected_model.model.layers[layer].register_forward_pre_hook(cap)
+    prompt = expected_tokenizer.apply_chat_template(
         [{"role": "user", "content": p}],
         tokenize=False,
         add_generation_prompt=True,
         enable_thinking=False,
     )
     with torch.no_grad():
-        model(**tokenizer(prompt, return_tensors="pt").to(DEVICE))
+        expected_model(**expected_tokenizer(prompt, return_tensors="pt").to(device))
     handle.remove()
     assert torch.allclose(one, grabbed["x"].to(one), atol=1e-2), (
         "Should be the last-token activation at LAYER"
     )
     # Harmful and harmless prompts must produce different activations (the premise of the method).
-    diff = (solution(HARMFUL_INSTRUCTIONS[:4]) - resid).norm().item()
+    diff = (solution(harmful_instructions[:4]) - resid).norm().item()
     assert diff > 0.1, (
         f"Harmful vs harmless activations should differ (got norm {diff:.3f})"
     )
@@ -219,17 +163,21 @@ def test_oproj(solution: Callable):
 
 @report
 def test_get_ablation_hooks(solution: Callable):
-    expected_model = solution.__globals__["model"]
+    from inspect import unwrap
+
+    expected_model = unwrap(solution).__globals__["model"]
+    n_layers = expected_model.config.num_hidden_layers
+    d_model = expected_model.config.hidden_size
     torch.manual_seed(0)
-    d = torch.randn(D_MODEL)
+    d = torch.randn(d_model)
     hooks = solution(d)
-    assert len(hooks) == N_LAYERS, (
-        f"Expected one hook per layer ({N_LAYERS}), got {len(hooks)}"
+    assert len(hooks) == n_layers, (
+        f"Expected one hook per layer ({n_layers}), got {len(hooks)}"
     )
     unit = d / d.norm()
-    x = torch.randn(2, 3, D_MODEL)
+    x = torch.randn(2, 3, d_model)
     # Every hook must be attached to the corresponding layer and project the direction out.
-    for i in range(0, N_LAYERS, max(1, N_LAYERS // 4)):
+    for i in range(0, n_layers, max(1, n_layers // 4)):
         module, hook = hooks[i]
         assert module is expected_model.model.layers[i], (
             f"Hook {i} should be attached to layer {i}"
@@ -244,14 +192,18 @@ def test_get_ablation_hooks(solution: Callable):
 
 @report
 def test_get_steering_hook(solution: Callable):
+    from inspect import unwrap
+
+    expected_model = unwrap(solution).__globals__["model"]
+    d_model = expected_model.config.hidden_size
     # Correctness on a synthetic activation: the hook must add exactly coeff*direction.
-    d = torch.ones(D_MODEL)
+    d = torch.ones(d_model)
     hooks = solution(d, coeff=2.0)
     assert len(hooks) == 1, "Steering resid at a single layer"
     module, hook = hooks[0]
     # Use batch > 1: a hook that returns tuple(tensor) instead of (tensor,) unpacks the batch
     # dimension and passes the wrong shape on, which only shows up when batch != 1.
-    x = torch.randn(2, 4, D_MODEL)
+    x = torch.randn(2, 4, d_model)
     result = hook(module, (x,))
     assert isinstance(result, tuple) and len(result) == 1, (
         "Hook must return a one-element tuple (the modified residual), not the unpacked tensor"
@@ -264,7 +216,7 @@ def test_get_steering_hook(solution: Callable):
         "Hook should add coeff*direction to the activation"
     )
     # It must act at the requested layer ...
-    assert solution(d, coeff=1.0, layer=3)[0][0] is model.model.layers[3], (
+    assert solution(d, coeff=1.0, layer=3)[0][0] is expected_model.model.layers[3], (
         "Steering should act at the requested layer"
     )
     # ... scale linearly with coeff ...


### PR DESCRIPTION
## Summary

- keep the Qwen model and tokenizer in the participant/reference answer module instead of emitting a second copy into section3_test.py
- retain the existing lightweight dataset test fixture
- resolve model-dependent test state from the submitted function's globals, so imported tests reuse the participant's existing model
- unwrap decorated submissions such as get_mean_activations before resolving their defining globals
- regenerate section3_test.py from the solution source of truth

The generated instructions are unchanged. This fixes the hook identity assertion and avoids loading a second Qwen3-1.7B model when section3_test is imported.

## Testing

- ./build-instructions.sh 5.3-undoing-safety-finetuning/section3_solution.py
- verified section3_instructions.md is byte-for-byte unchanged from main
- python -m py_compile on the solution and generated test
- verified generated section3_test.py contains no model or tokenizer instantiation
- synthetic checks for hook cache, projection, ablation, and steering, including decorated submitted functions
- ran the real participant answer through Exercise 5.3.4 on aisbrunbox; hook cache, mean activations, projection, and ablation tests all passed with one model load